### PR TITLE
fix: update default values for SendWSol component to match e2e requirements

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -74,6 +74,7 @@ export const Header: FC<HeaderProps> = () => {
           style={{ wordWrap: 'break-word', display: 'flex', flexDirection: 'row', alignItems: 'center', gap: '0.5rem' }}
         >
           <input
+            id={dataTestIds.testPage.header.endpoint}
             data-testid={dataTestIds.testPage.header.endpoint}
             type="text"
             value={tempEndpoint}

--- a/src/components/SendWSol.tsx
+++ b/src/components/SendWSol.tsx
@@ -124,9 +124,9 @@ export const SendWSol: FC = () => {
   const { publicKey, signTransaction, signAllTransactions, sendTransaction } = useWallet();
   const [signedTransactions, setSignedTransactions] = useState<VersionedTransaction[]>([]);
   const [sentTransactions, setSentTransactions] = useState<string[]>([]);
-  const [nbRandomAddress, setNbRandomAddress] = useState(1);
-  const [amount, setAmount] = useState(0.1);
-  const [inMultipleTransactions, setInMultipleTransactions] = useState(false);
+  const [nbRandomAddress, setNbRandomAddress] = useState(2);
+  const [amount, setAmount] = useState(0.001);
+  const [inMultipleTransactions, setInMultipleTransactions] = useState(true);
   const [loading, setLoading] = useState(false);
 
   /**


### PR DESCRIPTION
This PR updates the default values for SendWSol component to spare the E2E tests from having to update them